### PR TITLE
Fix matplotlib PendingDeprecationWarning for Colormap.set_bad

### DIFF
--- a/pygad/plotting/colormaps.py
+++ b/pygad/plotting/colormaps.py
@@ -13,7 +13,7 @@ from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
 def _create_new_listed_cm(name, data, bad='black'):
     cmap = ListedColormap(data, name=name)
-    cmap.set_bad(bad)
+    cmap = cmap.with_extremes(bad=bad)
     mpl.colormaps.register(name=name, cmap=cmap)
     return cmap
 
@@ -36,7 +36,7 @@ cm_age = LinearSegmentedColormap('age',
                    (1.0,  0.05, 0.05))
          }
                                  )
-cm_age.set_bad('black')
+cm_age = cm_age.with_extremes(bad='black')
 mpl.colormaps.register(name='age', cmap=cm_age)
 
 cm_k_g = LinearSegmentedColormap('BlackGreen',
@@ -50,7 +50,7 @@ cm_k_g = LinearSegmentedColormap('BlackGreen',
                    (1.0, 0.3, 0.3))
          }
                                  )
-cm_k_g.set_bad('black')
+cm_k_g = cm_k_g.with_extremes(bad='black')
 mpl.colormaps.register(name='BlackGreen', cmap=cm_k_g)
 
 cm_k_p = LinearSegmentedColormap('BlackPurple',
@@ -62,7 +62,7 @@ cm_k_p = LinearSegmentedColormap('BlackPurple',
                    (1.0, 1.0, 1.0))
          }
                                  )
-cm_k_p.set_bad('black')
+cm_k_p = cm_k_p.with_extremes(bad='black')
 mpl.colormaps.register(name='BlackPurple', cmap=cm_k_p)
 
 cm_isolum = [[ 0.60650245, 0.52403835, 0.96984564],

--- a/pygad/plotting/general.py
+++ b/pygad/plotting/general.py
@@ -283,7 +283,9 @@ def scatter_map(x, y, s=None, qty=None, av=None, bins=150, extent=None,
     if cmap is None:
         cmap = CM_DEF if colors is None else 'isolum'
         cmap = mpl.colormaps[cmap]
-        cmap.set_bad('w' if zero_is_white else 'k')
+        # work on a copy with adjusted extremes instead of mutating the
+        # colormap in place
+        cmap = cmap.with_extremes(bad='w' if zero_is_white else 'k')
         if fontcolor is None:
             fontcolor = 'k' if zero_is_white else 'w'
     if isinstance(cmap, str):


### PR DESCRIPTION
Replaces deprecated in-place `set_bad()` with `Colormap.with_extremes(bad=...)` in pygad/plotting/colormaps.py (4 spots) and pygad/plotting/general.py scatter_map. DO NOT MERGE — CI vehicle only; integration handled separately.