### PR TITLE
DO NOT MERGE: Fix NumPy 2.0 __array_wrap__ deprecation in UnitArr/SimArr/Map

### DIFF
--- a/pygad/binning/core.py
+++ b/pygad/binning/core.py
@@ -297,8 +297,8 @@ class Map(UnitArr):
         UnitArr.__array_finalize__(self, obj)
         self._extent = getattr(obj, '_extent', [[0, 0]] * len(self.shape))
 
-    def __array_wrap__(self, array, context=None):
-        return UnitArr.__array_wrap__(self, array, context)
+    def __array_wrap__(self, array, context=None, return_scalar=False):
+        return UnitArr.__array_wrap__(self, array, context, return_scalar)
 
     def __getitem__(self, key):
         from warnings import simplefilter

--- a/pygad/snapshot/sim_arr.py
+++ b/pygad/snapshot/sim_arr.py
@@ -88,12 +88,12 @@ class SimArr(UnitArr):
             if hasattr(a, '_dependencies'): del a._dependencies
             a = a.base
 
-    def __array_wrap__(self, array, context=None):
-        ua = UnitArr.__array_wrap__(self, array, context)
+    def __array_wrap__(self, array, context=None, return_scalar=False):
+        ua = UnitArr.__array_wrap__(self, array, context, return_scalar)
         # seems like if and only if context is None, its not from a ufunc but just
         # slicing/masking and/or setting inplace (i.e. from a __i*__ function like
         # __iadd__) -- in these cases, we don't want references to the snapshot
-        if context is not None:
+        if context is not None and ua is not self:
             # might even already be a UnitArr, but the reference can still exist!
             ua.view(SimArr).downgrade_to_UnitArr()
         return ua

--- a/pygad/units/unit_arr.py
+++ b/pygad/units/unit_arr.py
@@ -317,8 +317,15 @@ class UnitArr(np.ndarray):
         self._unit_carrier = getattr(obj, '_unit_carrier', self)
         self._units = getattr(obj, 'units', None)
 
-    def __array_wrap__(self, array, context=None):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
+        # Note: `return_scalar` (NumPy 2.0+) indicates that the ufunc result is
+        # 0-d and NumPy would return it as a scalar; for UnitArr the scalar
+        # representation *is* the 0-d UnitArr (cf. UnitScalar), so we keep it.
         if context is None:
+            return array
+        if array is self:
+            # in-place operation (out=self): values and units are already
+            # handled by the __i*__ operators; nothing to do here
             return array
 
         try:


### PR DESCRIPTION
Draft PR to run CI (PyTest CI only triggers on pull_request events since the workflow does not exist on the default branch yet). Integration into add-pytest-ci is handled separately — DO NOT MERGE.

Fixes the `__array_wrap__ must accept context and return_scalar arguments` deprecation warning category.